### PR TITLE
Add cross-platform helper functions to the list

### DIFF
--- a/charter-ietf-bpf.txt
+++ b/charter-ietf-bpf.txt
@@ -37,6 +37,8 @@ work item topics:
 * Cross-platform map types allowing native data structure access from
   eBPF programs,
 
+* Cross-platform helper functions, such as for manipulation of maps,
+
 * Cross-platform eBPF program types that define the higher level
   execution environment for eBPF programs,
 


### PR DESCRIPTION
It doesn't make sense to me to standardize cross-platform map types without being able to make use of them in BPF programs.