### PR TITLE
Fix up "bpf" and "eBPF" to say "BPF"

### DIFF
--- a/charter-ietf-bpf.txt
+++ b/charter-ietf-bpf.txt
@@ -10,7 +10,7 @@ implementations in network interface cards, Microsoft Windows, etc.
 There is currently no formal standard for eBPF and no clear scope
 for what is part of eBPF and what is not.
 
-The bpf working group is initially tasked with documenting the existing
+The BPF working group is initially tasked with documenting the existing
 state of the eBPF ecosystem, and a clear process for extensions,
 including initial extensions that are widely useful and showcase the
 process.  The working group shall not adopt new work until these

--- a/charter-ietf-bpf.txt
+++ b/charter-ietf-bpf.txt
@@ -4,14 +4,14 @@ eBPF (which is no longer an acronym for anything), also commonly referred
 to as BPF, is a technology with origins in the Linux kernel that can safely
 run programs in a privileged context such as the operating system kernel.
 
-eBPF is increasingly being used beyond just the Linux kernel, with
+BPF is increasingly being used beyond just the Linux kernel, with
 implementations in network interface cards, Microsoft Windows, etc.
 
-There is currently no formal standard for eBPF and no clear scope
-for what is part of eBPF and what is not.
+There is currently no formal standard for BPF and no clear scope
+for what is part of BPF and what is not.
 
 The BPF working group is initially tasked with documenting the existing
-state of the eBPF ecosystem, and a clear process for extensions,
+state of the BPF ecosystem, and a clear process for extensions,
 including initial extensions that are widely useful and showcase the
 process.  The working group shall not adopt new work until these
 documents have progressed to working group last call.
@@ -19,35 +19,35 @@ documents have progressed to working group last call.
 The working group will produce one or more documents on the following
 work item topics:
 
-* the eBPF instruction set architecture (ISA) that defines the
-  instructions and low-level virtual machine for eBPF programs,
+* the BPF instruction set architecture (ISA) that defines the
+  instructions and low-level virtual machine for BPF programs,
 
 * verifier expectations and building blocks for allowing safe execution
-  of untrusted eBPF programs,
+  of untrusted BPF programs,
 
 * the BPF Type Format (BTF) that defines debug information and
-  introspection capabilities for eBPF programs,
+  introspection capabilities for BPF programs,
 
-* the eBPF bindings for the ELF (Executable and Linkable Format)
+* the BPF bindings for the ELF (Executable and Linkable Format)
   executable file format,
 
 * the platform support ABI (Application Binary Interface), including
   calling convention, linker requirements, and relocations,
 
 * cross-platform map types allowing native data structure access from
-  eBPF programs,
+  BPF programs,
 
 * cross-platform helper functions, such as for manipulation of maps,
 
-* cross-platform eBPF program types that define the higher level
-  execution environment for eBPF programs,
+* cross-platform BPF program types that define the higher level
+  execution environment for BPF programs,
 
 * and an architecture and framework informational document.
 
-The BPF working group shall actively engage the eBPF Foundation
+The BPF working group shall actively engage the BPF Foundation
 steering committee and the broader implementation community to
 ensure inclusion in the IETF's consensus-driven process.
 
 The working group is intended to only work on cross-platform aspects of
-eBPF that are useful to the wider internet community and not operating
+BPF that are useful to the wider internet community and not operating
 system or otherwise platform specific.


### PR DESCRIPTION
In the modern age, when someone says "BPF", they're really always
referring to eBPF. To minimize confusion and converge on a single term,
let's convert eBPF throughout the charter doc to just say "BPF".